### PR TITLE
LIBFCREPO-1310: Updating the charset to utf-8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,160 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
 .coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/#use-with-ide
+.pdm.toml
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
 .venv
-*.sqlite3
-*.egg-info
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/

--- a/src/vocabs/views.py
+++ b/src/vocabs/views.py
@@ -132,7 +132,7 @@ class GraphView(DetailView):
             case 'ttl' | 'turtle':
                 return 'text/turtle', 'utf-8'
             case 'nt' | 'ntriples' | 'n-triples':
-                return 'application/n-triples', 'us-ascii'
+                return 'application/n-triples', 'utf-8'
             case _:
                 raise ValueError(f'Unknown format: {format_param}')
 
@@ -255,7 +255,7 @@ class ImportFormView(FormView):
                 uri=form.cleaned_data['uri'],
             )
         except ValueError:
-            messages.error(self.request, message=f'Unable to import vocabulary')
+            messages.error(self.request, message='Unable to import vocabulary')
             return super().form_invalid(form)
 
         if is_new or count['new_terms'] > 0 or count['new_properties'] > 0:

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -2,7 +2,6 @@ from contextlib import contextmanager
 from http import HTTPStatus
 
 import pytest
-
 from vocabs.models import Vocabulary
 
 
@@ -37,7 +36,7 @@ def test_list_prefixes(client):
 @pytest.mark.django_db
 def test_create_vocabulary(post, vocab_uri):
     response = post('/vocabs/', data={'uri': vocab_uri})
-    assert f'Vocabulary: Foo' in response.content.decode()
+    assert 'Vocabulary: Foo' in response.content.decode()
     assert len(Vocabulary.objects.all()) == 1
 
 
@@ -69,22 +68,22 @@ def test_create_and_update_vocabulary(post, vocab_uri):
         ('xml', 'application/rdf+xml; charset=utf-8'),
         ('ttl', 'text/turtle; charset=utf-8'),
         ('turtle', 'text/turtle; charset=utf-8'),
-        ('nt', 'application/n-triples; charset=us-ascii'),
-        ('ntriples', 'application/n-triples; charset=us-ascii'),
-        ('n-triples', 'application/n-triples; charset=us-ascii'),
+        ('nt', 'application/n-triples; charset=utf-8'),
+        ('ntriples', 'application/n-triples; charset=utf-8'),
+        ('n-triples', 'application/n-triples; charset=utf-8'),
     ]
 )
 @pytest.mark.django_db
 def test_graph(client, post, vocab_uri, format_param, expected_content_type):
     vocab_path = post('/vocabs/', data={'uri': vocab_uri}).wsgi_request.path
-    response = client.get(vocab_path + f'/graph', data={'format': format_param})
+    response = client.get(vocab_path + '/graph', data={'format': format_param})
     assert response.headers['Content-Type'] == expected_content_type
 
 
 @pytest.mark.django_db
 def test_graph_not_acceptable(client, post, vocab_uri):
     vocab_path = post('/vocabs/', data={'uri': vocab_uri}).wsgi_request.path
-    response = client.get(vocab_path + f'/graph', data={'format': 'NOT_A_VALID_FORMAT'})
+    response = client.get(vocab_path + '/graph', data={'format': 'NOT_A_VALID_FORMAT'})
     assert response.status_code == HTTPStatus.NOT_ACCEPTABLE
 
 


### PR DESCRIPTION
The encoding error was due to the charset of the n-triples not being utf-8.
It's us-ascii when being served as text/plain, but utf-8 when its application/n-triples: https://www.w3.org/TR/n-triples/#n-triples-mediatype

https://umd-dit.atlassian.net/browse/LIBFCREPO-1310