### PR TITLE
LIBFCREPO-1301. Use django-environ to read .env file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,16 @@ pip install ../plastron/plastron-utils
 pip install -e .
 ```
 
+Create a `.env` file in the project base directory that looks like this:
+
+```dotenv
+DATABASE_URL=sqlite:///db.sqlite3
+DEBUG=True
+# SECRET_KEY can be anything with sufficient randomness
+# one way of generating this is "uuidgen | shasum -a 256 | cut -c-64"
+SECRET_KEY=...
+```
+
 Initialize the database:
 
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,7 @@ name = "grove"
 version = "1.0.0-dev"
 dependencies = [
     "django~=5.0",
+    "django-environ~=0.11",
     "plastron-utils~=4.0",
     "rdflib~=7.0",
 ]

--- a/src/grove/settings.py
+++ b/src/grove/settings.py
@@ -12,18 +12,23 @@ https://docs.djangoproject.com/en/5.0/ref/settings/
 
 from pathlib import Path
 
-# Build paths inside the project like this: BASE_DIR / 'subdir'.
-BASE_DIR = Path(__file__).resolve().parent.parent
+from environ import Env
 
+# Build paths inside the project like this: BASE_DIR / 'subdir'.
+BASE_DIR = Path(__file__).resolve().parent.parent.parent
+
+# Take environment variables from .env file
+Env.read_env(BASE_DIR / '.env')
+env = Env()
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/5.0/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = 'django-insecure-q(svi#rpzo%fs^0(y1pf!ayopva)z+8x-b*%%f(5%qa=4#8!^c'
+SECRET_KEY = env.str('SECRET_KEY')
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
+DEBUG = env.bool('DEBUG', False)
 
 ALLOWED_HOSTS = []
 
@@ -75,10 +80,7 @@ WSGI_APPLICATION = 'grove.wsgi.application'
 # https://docs.djangoproject.com/en/5.0/ref/settings/#databases
 
 DATABASES = {
-    'default': {
-        'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': BASE_DIR / 'db.sqlite3',
-    }
+    'default': env.db_url(),
 }
 
 

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,0 +1,15 @@
+from importlib import reload
+
+from grove import settings
+
+
+def test_environment_variables(monkeypatch):
+    monkeypatch.setenv('DATABASE_URL', 'sqlite:///test-db.sqlite3')
+    monkeypatch.setenv('DEBUG', 'False')
+    monkeypatch.setenv('SECRET_KEY', 'foobar')
+    reload(settings)
+
+    assert settings.DEBUG is False
+    assert settings.SECRET_KEY == 'foobar'
+    assert settings.DATABASES['default']['ENGINE'] == 'django.db.backends.sqlite3'
+    assert settings.DATABASES['default']['NAME'] == 'test-db.sqlite3'


### PR DESCRIPTION
- DEBUG and SECRET_KEY settings are read from the .env file
- database connection config is parsed from DATABASE_URL in the .env file
- updated README with sample .env file

https://umd-dit.atlassian.net/browse/LIBFCREPO-1301