### PR TITLE
LIBFCREPO-1311. Added the ability to publish and unpublish vocabularies to static files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -158,3 +158,5 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+public

--- a/src/grove/settings.py
+++ b/src/grove/settings.py
@@ -124,3 +124,5 @@ STATIC_URL = 'static/'
 # https://docs.djangoproject.com/en/5.0/ref/settings/#default-auto-field
 
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
+
+VOCAB_OUTPUT_DIR = Path(env.str('VOCAB_OUTPUT_DIR', default=BASE_DIR / 'public'))

--- a/src/vocabs/templates/vocabs/vocabulary_detail.html
+++ b/src/vocabs/templates/vocabs/vocabulary_detail.html
@@ -7,6 +7,14 @@
   <a href="{% url 'show_graph' pk=vocabulary.id %}?format={{ param }}" target="_blank">{{ label }}</a>
   {% endfor %}
 </p>
+<form method="post" action="{% url 'publish_vocabulary' pk=vocabulary.id %}">
+  {% csrf_token %}
+  {% if vocabulary.is_published %}
+  <button type="submit" name="publish" value="false">Unpublish</button>
+  {% else %}
+  <button type="submit" name="publish" value="true">Publish</button>
+  {% endif %}
+</form>
 
 <div id="forms">
   <div id="details">

--- a/src/vocabs/urls.py
+++ b/src/vocabs/urls.py
@@ -1,13 +1,14 @@
 from django.urls import path
 
 from vocabs.views import (GraphView, IndexView, NewPropertyView, PredicatesView, PrefixList, PropertyEditView,
-                          PropertyView, TermView, VocabularyView, TermsView, ImportFormView)
+                          PropertyView, TermView, VocabularyView, TermsView, ImportFormView, PublishedVocabularyView)
 
 urlpatterns = [
     path('', IndexView.as_view(), name='list_vocabularies'),
     path('<int:pk>', VocabularyView.as_view(), name='show_vocabulary'),
     path('<int:pk>/terms', TermsView.as_view(), name='list_terms'),
     path('<int:pk>/graph', GraphView.as_view(), name='show_graph'),
+    path('<int:pk>/published', PublishedVocabularyView.as_view(), name='publish_vocabulary'),
     path('terms/<int:pk>', TermView.as_view(), name='show_term'),
     path('properties/new', NewPropertyView.as_view(), name='new_property'),
     path('properties/<int:pk>', PropertyView.as_view(), name='show_property'),

--- a/tests/test_vocabs/test_models/test_publish_vocabulary.py
+++ b/tests/test_vocabs/test_models/test_publish_vocabulary.py
@@ -1,0 +1,69 @@
+from pathlib import Path
+from typing import Iterator, Callable
+
+import pytest
+
+import vocabs
+from vocabs.models import Vocabulary, Term
+
+
+def published_files(vocabulary: Vocabulary, vocab_output_dir: Path) -> Iterator[Path]:
+    for fmt in Vocabulary.OUTPUT_FORMATS:
+        yield vocab_output_dir / (vocabulary.basename + '.' + fmt.extension)
+
+
+@pytest.fixture
+def create_vocab(monkeypatch, datadir) -> Callable[..., Vocabulary]:
+    monkeypatch.setattr(vocabs.models, 'VOCAB_OUTPUT_DIR', datadir)
+
+    def _create_vocab(published: bool = False):
+        vocab = Vocabulary(uri='http://example.com/foo#')
+        vocab.save()
+        term = Term(name='bar', vocabulary=vocab)
+        term.save()
+        if published:
+            vocab.publish()
+        return vocab
+
+    return _create_vocab
+
+
+@pytest.mark.django_db
+def test_vocabulary_starts_unpublished(datadir, create_vocab):
+    vocabulary = create_vocab(published=False)
+    assert not vocabulary.is_published
+    # no files should be present
+    for file in published_files(vocabulary=vocabulary, vocab_output_dir=datadir):
+        assert not file.exists()
+
+
+@pytest.mark.django_db
+def test_publish_vocabulary_creates_files(datadir, create_vocab):
+    vocabulary = create_vocab(published=False)
+    vocabulary.publish()
+    assert vocabulary.is_published
+
+    # publish should create all the files
+    for file in published_files(vocabulary=vocabulary, vocab_output_dir=datadir):
+        assert file.exists()
+
+
+@pytest.mark.django_db
+def test_unpublish_vocabulary_removes_files(datadir, create_vocab):
+    vocabulary = create_vocab(published=True)
+    vocabulary.unpublish()
+    assert not vocabulary.is_published
+
+    # unpublish should remove all the files
+    for file in published_files(vocabulary=vocabulary, vocab_output_dir=datadir):
+        assert not file.exists()
+
+
+@pytest.mark.django_db
+def test_unpublished_vocab_has_no_publication_date(create_vocab):
+    assert create_vocab(published=False).publication_date is None
+
+
+@pytest.mark.django_db
+def test_published_vocab_has_publication_date(create_vocab):
+    assert create_vocab(published=True).publication_date is not None


### PR DESCRIPTION
- added VOCAB_OUTPUT_DIR setting that is read from an environment variable; default value is "$BASE_DIR/public"
- added OutputFormat as a named tuple class
  - always serialize with utf-8 encoding
- added methods to the Vocabulary class
  - publish(): serializes the vocabulary in all supported output formats to the VOCAB_OUTPUT_DIR
  - unpublish(): deletes the serialized vocabulary files in all supported formats from the VOCAB_OUTPUT_DIR
- added properties to the Vocabulary class
  - basename: returns the last segment of the vocabulary URI without a trailing "#" or "/"
  - is_published: returns true if there is a file with every supported format in the VOCAB_OUTPUT_DIR for this vocabulary
  - publication_date: if published, returns the datetime (to the nearest second) of when the files were published; otherwise, returns None
- added PublishedVocabularyView at /published
  - GET: return JSON with the publication status and the date (only if published)
  - POST: publish or unpublish the vocabulary base on the value of the publish form parameter
- added "Publish" and "Unpublish" buttons to the vocabulary detail page
- added "public" to the .gitignore

https://umd-dit.atlassian.net/browse/LIBFCREPO-1311