### PR TITLE
LIBFCREPO-1331. Added ability to delete a vocabulary.

### DIFF
--- a/src/vocabs/templates/vocabs/base.html
+++ b/src/vocabs/templates/vocabs/base.html
@@ -6,4 +6,12 @@
 {% endblock %}
 {% block main %}
 {% block content %}{% endblock %}
+<script type="application/javascript">
+  document.body.addEventListener('htmx:beforeRequest', function (evt) {
+    // send the csrftoken as a header on DELETE requests
+    if (evt.detail.requestConfig.verb == 'delete') {
+      evt.detail.xhr.setRequestHeader('X-CSRFToken', cookieParser(document.cookie).csrftoken);
+    }
+  })
+</script>
 {% endblock %}

--- a/src/vocabs/templates/vocabs/vocabulary_detail.html
+++ b/src/vocabs/templates/vocabs/vocabulary_detail.html
@@ -71,12 +71,5 @@
       selectElement.value = 'Add a property';
     }
   });
-
-  document.body.addEventListener('htmx:beforeRequest', function (evt) {
-    // send the csrftoken as a header on DELETE requests
-    if (evt.detail.elt.className == 'delete') {
-      evt.detail.xhr.setRequestHeader('X-CSRFToken', cookieParser(document.cookie).csrftoken);
-    }
-  })
 </script>
 {% endblock %}

--- a/src/vocabs/templates/vocabs/vocabulary_list.html
+++ b/src/vocabs/templates/vocabs/vocabulary_list.html
@@ -8,11 +8,12 @@
     <th>Term Count</th>
     <th>URI</th>
     <th>Preview</th>
+    <th></th>
   </tr>
   </thead>
   <tbody>
   {% for vocab in vocabularies %}
-  <tr>
+  <tr class="vocabulary">
     <td>
       <a href="{% url 'show_vocabulary' pk=vocab.id %}">{{ vocab.label }}</a>
     </td>
@@ -29,6 +30,10 @@
       {% for param, label in formats.items %}
       <a href="{% url 'show_graph' pk=vocab.id %}?format={{ param }}">{{ label }}</a>
       {% endfor %}
+    </td>
+    <td>
+      <button class="delete" hx-delete="{% url 'show_vocabulary' pk=vocab.id %}" hx-target="closest .vocabulary" hx-swap="delete"
+              hx-confirm="Really delete the vocabulary '{{ vocab.label }}'?">Delete</button>
     </td>
   </tr>
   {% endfor %}

--- a/src/vocabs/views.py
+++ b/src/vocabs/views.py
@@ -100,6 +100,11 @@ class VocabularyView(LoginRequiredMixin, UpdateView):
         messages.error(self.request, message='Vocabulary cannot be updated due to validation errors')
         return super().form_invalid(form)
 
+    @method_decorator(ensure_csrf_cookie)
+    def delete(self, *_args, **_kwargs):
+        self.get_object().delete()
+        return HttpResponse(status=HTTPStatus.OK)
+
 
 class TermsView(LoginRequiredMixin, View):
     model = Vocabulary

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -67,6 +67,19 @@ def test_create_and_update_vocabulary(post, vocab_uri):
         assert vocab.preferred_prefix == 'foo'
 
 
+@pytest.mark.django_db
+def test_create_and_delete_vocabulary(post, vocab_uri, admin_client):
+    vocab_path = post('/vocabs/', data={'uri': vocab_uri}).wsgi_request.path
+    with Vocabulary.with_uri(vocab_uri) as vocab:
+        assert vocab.uri == vocab_uri
+        assert vocab.label == 'Foo'
+        assert vocab.description == ''
+        assert vocab.preferred_prefix == ''
+    admin_client.delete(vocab_path)
+    with pytest.raises(Vocabulary.DoesNotExist):
+        Vocabulary.objects.get(uri=vocab_uri)
+
+
 @pytest.mark.parametrize(
     ('format_param', 'expected_content_type'),
     [


### PR DESCRIPTION
- added "Delete" button to vocabulary list page
- moved the Javascript to add the CSRF token to DELETE requests into the main template
- added a delete() method to the VocabularyView

https://umd-dit.atlassian.net/browse/LIBFCREPO-1331