### PR TITLE
LIBFCREPO-1344. Added VS Code Dev Container setup and documentation

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,51 @@
+// Largely taken from https://github.com/devcontainers/images/blob/main/src/python/.devcontainer/devcontainer.json
+{
+  "name": "Grove",
+  "build": {
+    "dockerfile": "../Dockerfile.vscode"
+  },
+
+  // Features to add to the dev container. More info: https://containers.dev/features.
+  "features": {
+    "ghcr.io/devcontainers/features/common-utils:2":{
+        "installZsh": "true",
+        "configureZshAsDefaultShell": true,
+        "username": "vscode",
+        "userUid": "1000",
+        "userGid": "1000"
+        //"upgradePackages": "true"
+    },
+    "ghcr.io/devcontainers/features/python:1": "none",
+    "ghcr.io/devcontainers/features/git:1": {
+        "version": "latest",
+        "ppa": "false"
+    }
+},
+
+  // Use 'forwardPorts' to make a list of ports inside the container available locally.
+  // "forwardPorts": [],
+
+  // Use 'postCreateCommand' to run commands after the container is created.
+  "postCreateCommand": "pip install -e '.[test]'",
+
+  // Configure tool-specific properties.
+  // "customizations": {},
+
+  // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+  "remoteUser": "vscode",
+
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-python.python",
+        "charliermarsh.ruff",
+        "davidanson.vscode-markdownlint",
+        "eamodio.gitlens"
+      ],
+      // Set *default* container specific settings.json values on container create.
+      "settings": {
+        "python.defaultInterpreterPath": "/usr/local/bin/python"
+      }
+    }
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -163,6 +163,7 @@ public
 
 # SAML key/certificate files
 **/grove*.cer
+**/grove*.crt
 **/grove*.key
 
 staticfiles

--- a/.gitignore
+++ b/.gitignore
@@ -160,4 +160,12 @@ cython_debug/
 #.idea/
 
 public
+
+# SAML key/certificate files
+**/grove*.cer
+**/grove*.key
+
 staticfiles
+
+# Ruff cache
+.ruff_cache

--- a/Dockerfile.vscode
+++ b/Dockerfile.vscode
@@ -1,0 +1,10 @@
+# Pull base image
+FROM python:3.11.4-slim
+
+# Install git, vim, and xmlsec1
+RUN apt-get update && \
+    apt-get install -y git vim xmlsec1 && \
+    apt-get clean
+
+# Set vim as the default editor for Git
+ENV GIT_EDITOR=vim

--- a/README.md
+++ b/README.md
@@ -1,120 +1,13 @@
 # grove
 
-Grove RDF Ontology and Vocabulary Editor is a [Django]-based web 
-application for creating, editing, and publishing controlled vocabularies 
+Grove RDF Ontology and Vocabulary Editor is a [Django]-based web
+application for creating, editing, and publishing controlled vocabularies
 in RDF.
 
-## Development Environment
+## Development Environment Setup
 
-Requires:
-
-* Python 3.11
-
-### Setup
-
-Clone Grove from GitHub:
-
-```bash
-git clone git@github.com:umd-lib/grove
-cd grove
-python -m venv --prompt "grove-py$(cat .python-version)" .venv
-source .venv/bin/activate
-pip install -e .
-```
-
-Install `libxmlsec1`. This is required for the SAML authentication using
-[djangosaml2].
-
-On Mac, it is available via Homebrew:
-
-```bash
-brew install xmlsec1
-```
-
-On Debian or Ubuntu Linux, it is available via `apt`:
-
-```bash
-sudo apt-get install xmlsec1
-```
-
-Update the `/etc/hosts` file to add:
-
-```
-127.0.0.1 grove-local
-```
-
-Create a `.env` file in the project base directory that looks like this:
-
-```dotenv
-BASE_URL=http://grove-local:15001/
-DATABASE_URL=sqlite:///db.sqlite3
-DEBUG=True
-ENVIRONMENT=development
-# SECRET_KEY can be anything with sufficient randomness
-# one way of generating this is "uuidgen | shasum -a 256 | cut -c-64"
-SECRET_KEY=
-# SAML_KEY_FILE and SAML_CERT_FILE may be absolute or relative paths; if they
-# are relative they are relative to the project root directory
-# These can be downloaded from the grove-local-saml note in the Shared-SSDR 
-# folder on LastPass; note that local development uses the key and cert 
-# from the test server, so the file basename is "grove-test-lib-umd-edu"
-SAML_KEY_FILE=
-SAML_CERT_FILE=
-# absolute path to the xmlsec1 binary
-# you can find this by running "which xmlsec1"
-XMLSEC1_PATH=
-# for local (i.e., non-HTTPS) development, we disable the secure cookie flag
-SAML_SESSION_COOKIE_SAMESITE=Lax
-SESSION_COOKIE_SECURE=False
-```
-
-Initialize the database:
-
-```bash
-./src/manage.py migrate
-```
-
-Load the default set of predicates:
-
-```bash
-./src/manage.py load_predicates -f predicate.csv
-```
-
-Run the application. The default port is 15001; this is also the port that 
-is registered with DIT to allow SAML authentication to work from local:
-
-```bash
-./src/manage.py runserver
-```
-
-The application will be running at <http://grove-local:15001/>
-
-To change the port, provide an argument to `runserver`, e.g.:
-
-```bash
-./src/manage.py runserver 5555
-```
-
-### Tests
-
-To install test dependencies, install the `test` extra:
-
-```bash
-pip install -e .[test]
-```
-
-This project uses [pytest] in conjunction with the [pytest-django] plugin 
-to run its tests. To run the test suite:
-
-```bash
-pytest
-```
-
-To run with coverage information:
-
-```bash
-pytest --cov src --cov-report term-missing
-```
+* [VS Code Dev Container Setup](docs/DevelopmentEnvironmentVsCode.md)
+* [Local Development Environment Setup](docs/DevelopmentEnvironmentLocal.md)
 
 ## Building the Docker Image for local testing
 
@@ -154,8 +47,8 @@ GitHub for information about setting up a MacBook to use the Kubernetes
    directory:
 
     ```zsh
-    $ git clone git@github.com:umd-lib/grove.git
-    $ cd grove
+    git clone git@github.com:umd-lib/grove.git
+    cd grove
     ```
 
 2. Checkout the appropriate Git tag, branch, or commit for the Docker image.
@@ -163,7 +56,7 @@ GitHub for information about setting up a MacBook to use the Kubernetes
 3. Set up an "APP_TAG" environment variable:
 
     ```zsh
-    $ export APP_TAG=<DOCKER_IMAGE_TAG>
+    export APP_TAG=<DOCKER_IMAGE_TAG>
     ```
 
    where \<DOCKER_IMAGE_TAG> is the Docker image tag to associate with the
@@ -172,34 +65,30 @@ GitHub for information about setting up a MacBook to use the Kubernetes
    Git tag of "1.2.0":
 
     ```zsh
-    $ export APP_TAG=1.2.0
+    export APP_TAG=1.2.0
     ```
 
     Alternatively, to use the Git branch and commit:
 
     ```zsh
-    $ export GIT_BRANCH=`git rev-parse --abbrev-ref HEAD`
-    $ export GIT_COMMIT_HASH=`git rev-parse HEAD`
-    $ export APP_TAG=${GIT_BRANCH}-${GIT_COMMIT_HASH}
+    export GIT_BRANCH=`git rev-parse --abbrev-ref HEAD`
+    export GIT_COMMIT_HASH=`git rev-parse HEAD`
+    export APP_TAG=${GIT_BRANCH}-${GIT_COMMIT_HASH}
     ```
 
 4. Switch to the Kubernetes "build" namespace:
 
     ```bash
-    $ kubectl config use-context build
+    kubectl config use-context build
     ```
 
 5. Create the "docker.lib.umd.edu/grove" Docker image:
 
     ```bash
-    $ docker buildx build --no-cache --platform linux/amd64 --push --no-cache \
+    docker buildx build --no-cache --platform linux/amd64 --push --no-cache \
         --builder=kube  -f Dockerfile -t docker.lib.umd.edu/grove:$APP_TAG .
     ```
 
    The Docker image will be automatically pushed to the Nexus.
 
 [Django]: https://www.djangoproject.com/
-[Plastron]: https://github.com/umd-lib/plastron
-[djangosaml2]: https://djangosaml2.readthedocs.io/
-[pytest]: https://pytest.org/
-[pytest-django]: https://pytest-django.readthedocs.io/en/latest/

--- a/docs/DevelopmentEnvironmentLocal.md
+++ b/docs/DevelopmentEnvironmentLocal.md
@@ -1,0 +1,128 @@
+# Development Environment - Local
+
+## Introduction
+
+This document provides guidance on setting up a Grove development environment
+on a local workstation.
+
+**Note:** See
+[docs/DevelopmentEnvironmentVsCode.md](DevelopmentEnvironmentVsCode.md).
+for setting up a development environment using a VS Code Dev container.
+
+## Prerequisites
+
+* Python 3.11
+* Install `libxmlsec1`. This is required for the SAML authentication using
+  [djangosaml2].
+
+  On Mac, it is available via Homebrew:
+
+  ```zsh
+  brew install xmlsec1
+  ```
+
+  On Debian or Ubuntu Linux, it is available via `apt`:
+
+  ```zsh
+  sudo apt-get install xmlsec1
+  ```
+
+* Update the `/etc/hosts` file to add:
+
+  ```zsh
+  127.0.0.1 grove-local
+  ```
+
+## Application Setup
+
+1) Clone Grove from GitHub:
+
+    ```zsh
+    git clone git@github.com:umd-lib/grove
+    cd grove
+    ```
+
+2) Set up the Python virtual environment, and install the dependencies
+
+    ```zsh
+    python -m venv --prompt "grove-py$(cat .python-version)" .venv
+    source .venv/bin/activate
+    pip install -e .
+    ```
+
+3) Download the `grove-test-lib-umd-edu-sp.key` and
+  `grove-test-lib-umd-edu-sp.cer` files from the  "grove-local-saml" entry in
+   LastPass into the "grove" directory.
+
+    ℹ️ Note: These files can be placed in an directory outside the project,
+    if desired.
+
+4) Copy the "env_example" file to ".env":
+
+    ```zsh
+    cp env_example .env
+    ```
+
+    and update the following variables with the appropriate values:
+
+    * SAML_KEY_FILE - relative (or absolute) file path to the
+      `grove-test-lib-umd-edu-sp.key` file
+    * SAML_CERT_FILE - relative (or absolute) file path to the
+      ``grove-test-lib-umd-edu-sp.cer` file
+    * SECRET_KEY - Either comment out (a random key will be automatically
+      generated), or populate with anything with sufficient randomness,
+      i.e. `uuidgen | shasum -a 256 | cut -c-64`
+    * XMLSEC1_PATH - The full file path to the "xmlsec1" binary, (usually
+      findable by running `which xmlsec1`)
+
+5) Initialize the database:
+
+    ```zsh
+    ./src/manage.py migrate
+    ```
+
+6) Load the default set of predicates:
+
+    ```zsh
+    ./src/manage.py load_predicates -f predicate.csv
+    ```
+
+7) Run the application. The default port is 15001; this is also the port that
+   is registered with DIT to allow SAML authentication to work from local:
+
+    ```zsh
+    ./src/manage.py runserver
+    ```
+
+    The application will be running at <http://grove-local:15001/>
+
+    To change the port, provide an argument to `runserver`, e.g.:
+
+    ```zsh
+    ./src/manage.py runserver 5555
+    ```
+
+### Tests
+
+To install test dependencies, install the `test` extra:
+
+```zsh
+pip install -e '.[test]'
+```
+
+This project uses [pytest] in conjunction with the [pytest-django] plugin
+to run its tests. To run the test suite:
+
+```zsh
+pytest
+```
+
+To run with coverage information:
+
+```zsh
+pytest --cov src --cov-report term-missing
+```
+
+[djangosaml2]: https://djangosaml2.readthedocs.io/
+[pytest]: https://pytest.org/
+[pytest-django]: https://pytest-django.readthedocs.io/en/latest/

--- a/docs/DevelopmentEnvironmentLocal.md
+++ b/docs/DevelopmentEnvironmentLocal.md
@@ -51,11 +51,14 @@ for setting up a development environment using a VS Code Dev container.
     ```
 
 3) Download the `grove-test-lib-umd-edu-sp.key` and
-  `grove-test-lib-umd-edu-sp.cer` files from the  "grove-local-saml" entry in
+  `grove-test-lib-umd-edu-sp.crt` files from the  "grove-local-saml" entry in
    LastPass into the "grove" directory.
 
     ℹ️ Note: These files can be placed in an directory outside the project,
-    if desired.
+    if desired. Also, when downloading the `grove-test-lib-umd-edu-sp.crt`
+    file, Google Chrome will modify the file extension, by default, to ".cer".
+    Be sure to to specify the ".crt" extension when downloading the file.
+    Mozilla Firefox preserves the ".crt" extension.
 
 4) Copy the "env_example" file to ".env":
 
@@ -68,7 +71,7 @@ for setting up a development environment using a VS Code Dev container.
     * SAML_KEY_FILE - relative (or absolute) file path to the
       `grove-test-lib-umd-edu-sp.key` file
     * SAML_CERT_FILE - relative (or absolute) file path to the
-      ``grove-test-lib-umd-edu-sp.cer` file
+      ``grove-test-lib-umd-edu-sp.crt` file
     * SECRET_KEY - Either comment out (a random key will be automatically
       generated), or populate with anything with sufficient randomness,
       i.e. `uuidgen | shasum -a 256 | cut -c-64`

--- a/docs/DevelopmentEnvironmentVsCode.md
+++ b/docs/DevelopmentEnvironmentVsCode.md
@@ -1,0 +1,113 @@
+# Development Environment - VS Code Dev Container
+
+## Introduction
+
+This document provides guidance on setting up a Grove development environment
+using a VS Code Dev Container.
+
+**Note:** See
+[docs/DevelopmentEnvironmentLocal.md](DevelopmentEnvironmentLocal.md).
+for setting up a development environment locally.
+
+## Prerequisites
+
+* On the local workstation, update the `/etc/hosts` file to add:
+
+  ```zsh
+  127.0.0.1 grove-local
+  ```
+
+## Application Setup
+
+1) Clone Grove from GitHub:
+
+    ```zsh
+    git clone git@github.com:umd-lib/grove
+    cd grove
+    ```
+
+2) Open the "grove" in VS Code directory. A notification to reopen the folder
+   in a dev container will be displayed -- select "Reopen in Container"
+
+   ℹ️ Note: If there isn't a notification, you can also open the command palette
+   (CMD+Shift+P) and type `Dev Containers: Rebuild and Reopen in Container`
+
+   The dev container will build the Docker image (if necessary), and install
+   Python dependencies.
+
+3) Download the `grove-test-lib-umd-edu-sp.cer` and
+   `grove-test-lib-umd-edu-sp.key` files from the  "grove-local-saml" entry in
+   LastPass into the "grove" directory.
+
+4) In a VS Code terminal, run the following command to create a `.env` file
+   in the project base directory, and populates it with default values:
+
+    ```zsh
+    cp env_example .env &&
+       sed -i '/SAML_KEY_FILE=/cSAML_KEY_FILE=grove-test-lib-umd-edu-sp.key' .env &&
+       sed -i '/SAML_CERT_FILE=/cSAML_CERT_FILE=grove-test-lib-umd-edu-sp.cer' .env &&
+       sed -i '/SECRET_KEY=/c#SECRET_KEY=' .env
+       sed -i '/XMLSEC1_PATH=/cXSMLSEC1_PATH=/usr/bin/xmlsec1' .env
+    ```
+
+    ℹ️ Note: The `SECRET_KEY` does not need to be set for local development, as
+    a random string will be generated automatically, if necessary.
+
+5) Initialize the database:
+
+    ```zsh
+    ./src/manage.py migrate
+    ```
+
+6) Load the default set of predicates:
+
+    ```zsh
+    ./src/manage.py load_predicates -f predicate.csv
+    ```
+
+7) Run the application. The default port is 15001; this is also the port that
+   is registered with DIT to allow SAML authentication to work from local:
+
+    ```zsh
+    ./src/manage.py runserver
+    ```
+
+    The application will be running at <http://grove-local:15001/>
+
+    ℹ️ Note: VS Code "launch" configurations are also available for running
+    the above commands
+
+    To change the port, provide an argument to `runserver`, e.g.:
+
+    ```zsh
+    ./src/manage.py runserver 5555
+    ```
+
+## Application Dependencies
+
+The Python application dependencies (including test dependencies) are
+automatically installed when the dev container is started.
+
+To reinstall the dependencies, run
+
+```zsh
+pip install -e '.[test]'
+```
+
+## Tests
+
+This project uses [pytest] in conjunction with the [pytest-django] plugin
+to run its tests. To run the test suite:
+
+```zsh
+pytest
+```
+
+To run with coverage information:
+
+```zsh
+pytest --cov src --cov-report term-missing
+```
+
+[pytest]: https://pytest.org/
+[pytest-django]: https://pytest-django.readthedocs.io/en/latest/

--- a/docs/DevelopmentEnvironmentVsCode.md
+++ b/docs/DevelopmentEnvironmentVsCode.md
@@ -35,9 +35,14 @@ for setting up a development environment locally.
    The dev container will build the Docker image (if necessary), and install
    Python dependencies.
 
-3) Download the `grove-test-lib-umd-edu-sp.cer` and
+3) Download the `grove-test-lib-umd-edu-sp.crt` and
    `grove-test-lib-umd-edu-sp.key` files from the  "grove-local-saml" entry in
    LastPass into the "grove" directory.
+
+   ℹ️ Note: When downloading the `grove-test-lib-umd-edu-sp.crt` file, Google
+   Chrome will modify the file extension by default to ".cer". Be sure to to
+   specify the ".crt" extension when downloading the file. Mozilla Firefox
+   preserves the ".crt" extension.
 
 4) In a VS Code terminal, run the following command to create a `.env` file
    in the project base directory, and populates it with default values:
@@ -45,7 +50,7 @@ for setting up a development environment locally.
     ```zsh
     cp env_example .env &&
        sed -i '/SAML_KEY_FILE=/cSAML_KEY_FILE=grove-test-lib-umd-edu-sp.key' .env &&
-       sed -i '/SAML_CERT_FILE=/cSAML_CERT_FILE=grove-test-lib-umd-edu-sp.cer' .env &&
+       sed -i '/SAML_CERT_FILE=/cSAML_CERT_FILE=grove-test-lib-umd-edu-sp.crt' .env &&
        sed -i '/SECRET_KEY=/c#SECRET_KEY=' .env
        sed -i '/XMLSEC1_PATH=/cXSMLSEC1_PATH=/usr/bin/xmlsec1' .env
     ```

--- a/env_example
+++ b/env_example
@@ -1,0 +1,20 @@
+BASE_URL=http://grove-local:15001/
+DATABASE_URL=sqlite:///db.sqlite3
+DEBUG=True
+ENVIRONMENT=development
+# SECRET_KEY can be anything with sufficient randomness
+# one way of generating this is "uuidgen | shasum -a 256 | cut -c-64"
+SECRET_KEY=
+# SAML_KEY_FILE and SAML_CERT_FILE may be absolute or relative paths; if they
+# are relative they are relative to the project root directory
+# These can be downloaded from the grove-local-saml note in the Shared-SSDR
+# folder on LastPass; note that local development uses the key and cert
+# from the test server, so the file basename is "grove-test-lib-umd-edu"
+SAML_KEY_FILE=
+SAML_CERT_FILE=
+# absolute path to the xmlsec1 binary
+# you can find this by running "which xmlsec1"
+XMLSEC1_PATH=
+# for local (i.e., non-HTTPS) development, we disable the secure cookie flag
+SAML_SESSION_COOKIE_SAMESITE=Lax
+SESSION_COOKIE_SECURE=False


### PR DESCRIPTION
* Added a “Dockerfile.vscode” file for creating a suitable Docker image for local development, including the addition of the “xmlsec1” system package needed for SAML

* Added “.devcontainer/devcontainer.json” for configuring the VS Code Dev Container, including providing the following VS Code extensions:
    * Python (ms-python.python)
    * Ruff (charliermarsh.ruff)
    * markdownlint (davidanson.vscode-markdownlint)

* Modified the “README.md”, replacing the existing local development instructions with two separate files:
    * docs/DevelopmentEnvironmentLocal.md
    * docs/DevelopmentEnvironmentVsCode.md

* Updated the “.gitignore” file to ignore the SAML key and certificate files

https://umd-dit.atlassian.net/browse/LIBFCREPO-1344