### PR TITLE
LIBFCREPO-1334. Add "Publish Updates" button

### DIFF
--- a/src/vocabs/templates/vocabs/base.html
+++ b/src/vocabs/templates/vocabs/base.html
@@ -3,6 +3,7 @@
 {% block head %}
 <script src="{% static 'vocabs/grove.js' %}"></script>
 <link rel="stylesheet" type="text/css" href="{% static 'vocabs/vocab.css' %}" />
+<meta name="htmx-config" content='{"useTemplateFragments":"true"}'>
 {% endblock %}
 {% block main %}
 {% block content %}{% endblock %}

--- a/src/vocabs/templates/vocabs/publish_updates_button.html
+++ b/src/vocabs/templates/vocabs/publish_updates_button.html
@@ -1,0 +1,5 @@
+{% if show_publish_updates_button %}
+<span id="publish_updates" hx-swap-oob="true"><button class="publish" type="submit" name="publish" value="true">Publish Updates</button></span>
+{% else %}
+<span id="publish_updates"></span>
+{% endif %}

--- a/src/vocabs/templates/vocabs/vocabulary_detail.html
+++ b/src/vocabs/templates/vocabs/vocabulary_detail.html
@@ -14,6 +14,7 @@
   {% csrf_token %}
   {% if vocabulary.is_published %}
   <button class="unpublish" type="submit" name="publish" value="false">Unpublish</button>
+  {% include 'vocabs/publish_updates_button.html' with show_publish_updates_button=vocabulary.has_updated %}
   {% else %}
   <button class="publish" type="submit" name="publish" value="true">Publish</button>
   {% endif %}


### PR DESCRIPTION
Implemented using a “PublishUpdatesMixin” class, that can be added to the
various Django views that trigger changes to the Vocabulary, Term, or
Property models:

* TermsView
* TermView
* PropertyView
* PropertyEditView

Because the “PublishUpdatesMixin” can be called from a variety of views,
the logic for determining whether the vocabulary has publishable updates
has been encapsulated in the “vocabulary_has_updated” method, which does
the following:

* Any DELETE or POST request is assumed to be an update. This is needed
  because we can't retrieve the object on DELETE requests, and some
  POSTS (such as from TermsView) don't use templates, and so don't
  respond to "self.get_object".
* All other requests are assume to respond to “self.get_object”. If the
  returned object is a Property, Term, or Vocabulary instance, the
  “has_updated” method on the associated vocabulary object is called
* All other cases return False

The PublishUpdatesMixin renders the
“src/vocabs/templates/vocabs/publish_updates_button.html” template, to
show the button (passing a “show_publish_updates_button” variable in
template context), appending it on to whatever content is already being
returned by the view.

The template uses the HTMX “hx-swap-oob” directive to piggy-back the
display of the “Publish Updates” button onto any content change, so that
the “Publish Updates” button is displayed in the correct location.

Also added the HTMX "useTemplateFragments" to the "head" block of
the "vocabs/base.html" template. The "hx-swap-oob" directive has
problems with responses returning HTML "table" fragments.
Enabling the HTMX "useTemplateFragments"
attribute appears to fix the issue (originally suggested in
https://stackoverflow.com/a/77255665).

Note: The "useTemplateFragments" directive does not work with
Internet Explorer 11, but as IE11 was retired in June, 2022, and replaced with
Microsoft Edge, we presumably don't need to worry about it.

https://umd-dit.atlassian.net/browse/LIBFCREPO-1334
