### PR TITLE
LIBFCREPO-1355. Added validation for URI values of properties.

### DIFF
--- a/src/vocabs/models.py
+++ b/src/vocabs/models.py
@@ -231,7 +231,10 @@ class Property(TimeStampedModel, SafeDeleteModel):
 
     @property
     def value_as_curie(self) -> str:
-        curie = URIRef(str(self.value)).n3(namespace_manager=nsm)
+        try:
+            curie = URIRef(str(self.value)).n3(namespace_manager=nsm)
+        except Exception:  # noqa
+            curie = str(self.value)
         return curie if len(curie) <= len(str(self.value)) else str(self.value)
 
     @property

--- a/src/vocabs/static/vocabs/vocab.css
+++ b/src/vocabs/static/vocabs/vocab.css
@@ -5,6 +5,8 @@ td {
 fieldset {
     display: inline-block;
     border: none;
+    margin: 0;
+    padding: 0;
 }
 
 ul {
@@ -66,7 +68,14 @@ form {
     grid-template-columns: auto auto 1fr;
     grid-template-rows: 100%;
     grid-column-gap: .5em;
-    align-items: center;
+    align-items: start;
+}
+.property>form {
+    display: grid;
+    grid-template-columns: auto 1fr auto auto;
+    grid-template-rows: 100%;
+    grid-column-gap: .5em;
+    align-items: start;
 }
 .property:hover {
     background-color: var(--info-subtle);

--- a/src/vocabs/templates/vocabs/new_property.html
+++ b/src/vocabs/templates/vocabs/new_property.html
@@ -1,7 +1,11 @@
 <li class="property">
   <form method="post" action="{% url 'new_property' %}">
     {% csrf_token %}
-    {{ form.term }} {{ form.predicate }} {{ form.value }}
+    {{ form.term }} {{ form.predicate }}
+    <fieldset>
+      {{ form.value }}
+      {{ form.value.errors }}
+    </fieldset>
     <button class="update" hx-post="{% url 'new_property' %}" hx-target="closest .property" type="submit">Save</button>
     <button onclick="this.parentNode.parentNode.remove()">Cancel</button>
   </form>

--- a/src/vocabs/templates/vocabs/property_form.html
+++ b/src/vocabs/templates/vocabs/property_form.html
@@ -1,11 +1,10 @@
 <form method="post" action="{% url 'edit_property' pk=property.id %}">
   {% csrf_token %}
-  {{ form.term }} {{ form.predicate }} <fieldset>{{ form.value }}
-  {% if property.predicate.object_type == 'Literal' %}
-  <!-- input size="3" name="language" placeholder="Lang"/>
-  <input name="datatype" placeholder="Type"/ -->
-  {% endif %}
-</fieldset>
+  {{ form.term }} {{ form.predicate }}
+  <fieldset>
+    {{ form.value }}
+    {{ form.value.errors }}
+  </fieldset>
   <button class="update" hx-post="{% url 'edit_property' pk=property.id %}" hx-target="closest .property" type="submit">Save</button>
   <button hx-get="{% url 'show_property' pk=property.id %}" hx-target="closest .property">Cancel</button>
 </form>


### PR DESCRIPTION
- raise a ValidationError if the value field contains characters that will cause rdflib to reject it as a URIRef value
- display the validation error message for the value field on the property form
- tweak the CSS to make the property display and form render correctly
- added tests of the URI value validation

https://umd-dit.atlassian.net/browse/LIBFCREPO-1355