### PR TITLE
LIBFCREPO-1350. Require the name parameter when creating a new term.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ dependencies = [
     "django~=5.0",
     "django-environ~=0.11",
     "django-extensions~=3.2",
+    "django-htmx~=1.17",
     "django-safedelete~=1.3",
     "djangosaml2~=1.9",
     "django-umd-lib-style@git+https://github.com/umd-lib/django-umd-lib-style.git@main",

--- a/src/grove/settings.py
+++ b/src/grove/settings.py
@@ -78,6 +78,7 @@ INSTALLED_APPS = [
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'djangosaml2',
+    'django_htmx',
 ]
 
 MIDDLEWARE = [
@@ -90,6 +91,7 @@ MIDDLEWARE = [
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'djangosaml2.middleware.SamlSessionMiddleware',
+    'django_htmx.middleware.HtmxMiddleware',
 ]
 
 ROOT_URLCONF = 'grove.urls'

--- a/src/vocabs/templates/vocabs/vocabulary_detail.html
+++ b/src/vocabs/templates/vocabs/vocabulary_detail.html
@@ -51,15 +51,15 @@
 
   <details id="new-terms" open>
     <summary><h2>Create New Term</h2></summary>
-    <form method="post" action="{% url 'list_terms' pk=vocabulary.id %}">
+    <form method="post" action="{% url 'list_terms' pk=vocabulary.id %}" hx-boost="true" hx-target="#terms tbody" hx-swap="beforeend">
       {% csrf_token %}
-      <input name="term_name" placeholder="Name" />
+      <input name="term_name" placeholder="Name" required/>
       <select name="rdf_type">
         <option value="">Basic term</option>
         <option value="rdfs:Class">Class</option>
         <option value="rdfs:Datatype">Datatype</option>
       </select>
-      <button class="create" type="submit" hx-post="{% url 'list_terms' pk=vocabulary.id %}" hx-target="previous tbody" hx-swap="beforeend">Add Term</button>
+      <button class="create" type="submit">Add Term</button>
     </form>
   </details>
 </div>


### PR DESCRIPTION
- server side returns a 400 Bad Request if name is blank
- client side adds the "required" parameter to the input element
- switched the HTMX enhancement to a boost of the form
  - reduces duplication of the method and action parameters
  - allows the browser-native validation (i.e., checking the required fields) to happen, since those happen on submit events
- added django-htmx as a dependency; Allows for easier checks of whether a request is HTMX or not

https://umd-dit.atlassian.net/browse/LIBFCREPO-1350