### PR TITLE
LIBFCREPO-1351. Moved HTMX attributes to the form level for the property forms.

### DIFF
--- a/src/vocabs/templates/vocabs/new_property.html
+++ b/src/vocabs/templates/vocabs/new_property.html
@@ -1,12 +1,12 @@
 <li class="property">
-  <form method="post" action="{% url 'new_property' %}">
+  <form method="post" action="{% url 'new_property' %}" hx-boost="true" hx-push-url="false" hx-target="closest .property">
     {% csrf_token %}
     {{ form.term }} {{ form.predicate }}
     <fieldset>
       {{ form.value }}
       {{ form.value.errors }}
     </fieldset>
-    <button class="update" hx-post="{% url 'new_property' %}" hx-target="closest .property" type="submit">Save</button>
+    <button class="update" type="submit">Save</button>
     <button onclick="this.parentNode.parentNode.remove()">Cancel</button>
   </form>
 </li>

--- a/src/vocabs/templates/vocabs/new_property.html
+++ b/src/vocabs/templates/vocabs/new_property.html
@@ -1,5 +1,6 @@
 <li class="property">
-  <form method="post" action="{% url 'new_property' %}" hx-boost="true" hx-push-url="false" hx-target="closest .property">
+  <form method="post" action="{% url 'new_property' %}" hx-boost="true" hx-push-url="false"
+        hx-target="closest .property" hx-swap="outerHTML">
     {% csrf_token %}
     {{ form.term }} {{ form.predicate }}
     <fieldset>

--- a/src/vocabs/templates/vocabs/property_detail.html
+++ b/src/vocabs/templates/vocabs/property_detail.html
@@ -1,10 +1,12 @@
-<strong title="{{ property.predicate.uri }}">{{ property.predicate }}</strong>
-{% if property.value_is_uri %}
-<a href="{{ property.value }}">{{ property.value_as_curie }}</a>
-{% else %}
-{{ property.value }}
-{% endif %}
-<span class="controls">
-  <button class="edit" hx-get="{% url 'edit_property' pk=property.id %}" hx-target="closest .property" title="Edit">✎</button>
-  <button class="delete" hx-delete="{% url 'show_property' pk=property.id %}" hx-swap="delete" hx-target="closest .property" title="Delete">╳</button>
-</span>
+<li class="property">
+  <strong title="{{ property.predicate.uri }}">{{ property.predicate }}</strong>
+  {% if property.value_is_uri %}
+  <a href="{{ property.value }}">{{ property.value_as_curie }}</a>
+  {% else %}
+  {{ property.value }}
+  {% endif %}
+  <span class="controls">
+    <button class="edit" hx-get="{% url 'edit_property' pk=property.id %}" hx-swap="outerHTML" hx-target="closest .property" title="Edit">✎</button>
+    <button class="delete" hx-delete="{% url 'show_property' pk=property.id %}" hx-swap="delete" hx-target="closest .property" title="Delete">╳</button>
+  </span>
+</li>

--- a/src/vocabs/templates/vocabs/property_form.html
+++ b/src/vocabs/templates/vocabs/property_form.html
@@ -1,10 +1,10 @@
-<form method="post" action="{% url 'edit_property' pk=property.id %}">
+<form method="post" action="{% url 'edit_property' pk=property.id %}" hx-boost="true" hx-push-url="false" hx-target="closest .property">
   {% csrf_token %}
   {{ form.term }} {{ form.predicate }}
   <fieldset>
     {{ form.value }}
     {{ form.value.errors }}
   </fieldset>
-  <button class="update" hx-post="{% url 'edit_property' pk=property.id %}" hx-target="closest .property" type="submit">Save</button>
+  <button class="update" type="submit">Save</button>
   <button hx-get="{% url 'show_property' pk=property.id %}" hx-target="closest .property">Cancel</button>
 </form>

--- a/src/vocabs/templates/vocabs/property_form.html
+++ b/src/vocabs/templates/vocabs/property_form.html
@@ -1,10 +1,13 @@
-<form method="post" action="{% url 'edit_property' pk=property.id %}" hx-boost="true" hx-push-url="false" hx-target="closest .property">
-  {% csrf_token %}
-  {{ form.term }} {{ form.predicate }}
-  <fieldset>
-    {{ form.value }}
-    {{ form.value.errors }}
-  </fieldset>
-  <button class="update" type="submit">Save</button>
-  <button hx-get="{% url 'show_property' pk=property.id %}" hx-target="closest .property">Cancel</button>
-</form>
+<li class="property">
+  <form method="post" action="{% url 'edit_property' pk=property.id %}" hx-boost="true" hx-push-url="false"
+        hx-target="closest .property" hx-swap="outerHTML">
+    {% csrf_token %}
+    {{ form.term }} {{ form.predicate }}
+    <fieldset>
+      {{ form.value }}
+      {{ form.value.errors }}
+    </fieldset>
+    <button class="update" type="submit">Save</button>
+    <button hx-get="{% url 'show_property' pk=property.id %}" hx-target="closest .property">Cancel</button>
+  </form>
+</li>

--- a/src/vocabs/templates/vocabs/term.html
+++ b/src/vocabs/templates/vocabs/term.html
@@ -5,7 +5,7 @@
     <td>
         <ul class="properties">
             {% for property in term.properties.all %}
-            <li class="property">{% include 'vocabs/property_detail.html' %}</li>
+            {% include 'vocabs/property_detail.html' %}
             {% endfor %}
         </ul>
         <div class="properties-controls">

--- a/src/vocabs/templates/vocabs/vocabulary_detail.html
+++ b/src/vocabs/templates/vocabs/vocabulary_detail.html
@@ -51,7 +51,8 @@
 
   <details id="new-terms" open>
     <summary><h2>Create New Term</h2></summary>
-    <form method="post" action="{% url 'list_terms' pk=vocabulary.id %}" hx-boost="true" hx-target="#terms tbody" hx-swap="beforeend">
+    <form method="post" action="{% url 'list_terms' pk=vocabulary.id %}"
+          hx-boost="true" hx-target="#terms tbody" hx-swap="beforeend" hx-push-url="false">
       {% csrf_token %}
       <input name="term_name" placeholder="Name" required/>
       <select name="rdf_type">


### PR DESCRIPTION
- hooks HTMX into the form submit event rather than the button click for the submit button
- allows the browser-native validation to run; specifically, the "required" attribute that prevents submitting the form if the value field is empty

https://umd-dit.atlassian.net/browse/LIBFCREPO-1351