### PR TITLE
LIBFCREPO-1351. Fix "li" nesting when property action is invalid

### DIFF
--- a/src/vocabs/templates/vocabs/new_property.html
+++ b/src/vocabs/templates/vocabs/new_property.html
@@ -6,7 +6,7 @@
       {{ form.value }}
       {{ form.value.errors }}
     </fieldset>
-    <button class="update" hx-post="{% url 'new_property' %}" hx-target="closest .property" type="submit">Save</button>
+    <button class="update" hx-post="{% url 'new_property' %}" hx-target="closest .property" hx-swap="outerHTML" type="submit">Save</button>
     <button onclick="this.parentNode.parentNode.remove()">Cancel</button>
   </form>
 </li>

--- a/src/vocabs/templates/vocabs/property_detail.html
+++ b/src/vocabs/templates/vocabs/property_detail.html
@@ -1,10 +1,12 @@
-<strong title="{{ property.predicate.uri }}">{{ property.predicate }}</strong>
-{% if property.value_is_uri %}
-<a href="{{ property.value }}">{{ property.value_as_curie }}</a>
-{% else %}
-{{ property.value }}
-{% endif %}
-<span class="controls">
-  <button class="edit" hx-get="{% url 'edit_property' pk=property.id %}" hx-target="closest .property" title="Edit">✎</button>
-  <button class="delete" hx-delete="{% url 'show_property' pk=property.id %}" hx-swap="delete" hx-target="closest .property" title="Delete">╳</button>
-</span>
+<li class="property">
+  <strong title="{{ property.predicate.uri }}">{{ property.predicate }}</strong>
+  {% if property.value_is_uri %}
+  <a href="{{ property.value }}">{{ property.value_as_curie }}</a>
+  {% else %}
+  {{ property.value }}
+  {% endif %}
+  <span class="controls">
+    <button class="edit" hx-get="{% url 'edit_property' pk=property.id %}" hx-target="closest .property" hx-swap="outerHTML" title="Edit">✎</button>
+    <button class="delete" hx-delete="{% url 'show_property' pk=property.id %}" hx-swap="delete" hx-target="closest .property" hx-swap="outerHTML" title="Delete">╳</button>
+  </span>
+</li>

--- a/src/vocabs/templates/vocabs/property_form.html
+++ b/src/vocabs/templates/vocabs/property_form.html
@@ -1,10 +1,12 @@
-<form method="post" action="{% url 'edit_property' pk=property.id %}">
-  {% csrf_token %}
-  {{ form.term }} {{ form.predicate }}
-  <fieldset>
-    {{ form.value }}
-    {{ form.value.errors }}
-  </fieldset>
-  <button class="update" hx-post="{% url 'edit_property' pk=property.id %}" hx-target="closest .property" type="submit">Save</button>
-  <button hx-get="{% url 'show_property' pk=property.id %}" hx-target="closest .property">Cancel</button>
-</form>
+<li class="property">
+  <form method="post" action="{% url 'edit_property' pk=property.id %}">
+    {% csrf_token %}
+    {{ form.term }} {{ form.predicate }}
+    <fieldset>
+      {{ form.value }}
+      {{ form.value.errors }}
+    </fieldset>
+    <button class="update" hx-post="{% url 'edit_property' pk=property.id %}" hx-target="closest .property" hx-swap="outerHTML" type="submit">Save</button>
+    <button hx-get="{% url 'show_property' pk=property.id %}" hx-target="closest .property" hx-swap="outerHTML">Cancel</button>
+  </form>
+</li>

--- a/src/vocabs/templates/vocabs/term.html
+++ b/src/vocabs/templates/vocabs/term.html
@@ -5,7 +5,7 @@
     <td>
         <ul class="properties">
             {% for property in term.properties.all %}
-            <li class="property">{% include 'vocabs/property_detail.html' %}</li>
+            {% include 'vocabs/property_detail.html' %}
             {% endfor %}
         </ul>
         <div class="properties-controls">


### PR DESCRIPTION
Fixed a display issue in which every time an property entry was not valid, an additional "<li>" stanza was nested inside the outer <li> stanza. This resulted in the "Property" form slowly expanding, even to the point of changing the width of the "Properties" column in the table.

Fixed by adding the "hx-swap" directive with "outerHTML", so that the `<li class="property">` stanza would be swapped out completely, instead of being nested inside. This required changing the "property_detail.html" and "property_form.html" templates to include the `<li class="property">` stanza.

https://umd-dit.atlassian.net/browse/LIBFCREPO-1351