### PR TITLE
LIBFCREPO-1363. Added term name validation.

### DIFF
--- a/src/vocabs/models.py
+++ b/src/vocabs/models.py
@@ -1,4 +1,5 @@
 import logging
+import re
 from collections import Counter
 from contextlib import contextmanager
 from datetime import datetime, timezone
@@ -40,6 +41,12 @@ GraphSource: TypeAlias = IO[bytes] | TextIO | InputSource | str | bytes | PurePa
 class VocabularyURIValidator(RegexValidator):
     regex = r'.+[/#]$'
     message = 'Must end with "/" or "#"'
+
+
+class TermNameValidator(RegexValidator):
+    regex = r'^[a-z0-9_-]+$'
+    flags = re.IGNORECASE
+    message = 'Term names may only contain A-Z, a-z, 0-9, and "-" and "_"'
 
 
 class Context(dict):
@@ -192,7 +199,7 @@ class Term(TimeStampedModel, SafeDeleteModel):
     _safedelete_policy = SOFT_DELETE_CASCADE
 
     vocabulary = ForeignKey(Vocabulary, on_delete=CASCADE, related_name='terms')
-    name = CharField(max_length=256)
+    name = CharField(max_length=256, validators=[TermNameValidator()])
 
     @property
     def uri(self):

--- a/src/vocabs/templates/vocabs/new_term_form.html
+++ b/src/vocabs/templates/vocabs/new_term_form.html
@@ -5,5 +5,6 @@
   {{ form.name }}
   {{ form.rdf_type }}
   <button class="create" type="submit">Add Term</button>
+  {{ form.name.errors }}
   {{ form.non_field_errors }}
 </form>

--- a/tests/test_vocabs/test_forms.py
+++ b/tests/test_vocabs/test_forms.py
@@ -1,7 +1,7 @@
 import pytest
 from plastron.namespaces import rdf, rdfs
 
-from vocabs.forms import VocabularyForm, PropertyForm
+from vocabs.forms import VocabularyForm, PropertyForm, TermForm
 from vocabs.models import Vocabulary, Term, Predicate
 
 
@@ -75,4 +75,21 @@ def test_property_form(vocab, rdf_type_predicate, term):
 )
 def test_property_form_uriref_validation(vocab, rdf_type_predicate, term, value, expected_validity):
     form = PropertyForm({'term': term, 'predicate': rdf_type_predicate, 'value': value})
+    assert form.is_valid() == expected_validity
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    ('name', 'expected_validity'),
+    [
+        ('basic', True),
+        ('moreComplex12', True),
+        ('with spaces', False),
+        ('other.punctuation!', False),
+        ('hyphen-is-okay', True),
+        ('so_is_underscore', True),
+    ]
+)
+def test_term_form_name_validation(vocab, name, expected_validity):
+    form = TermForm({'name': name, 'vocabulary': vocab})
     assert form.is_valid() == expected_validity


### PR DESCRIPTION
Must be alphanumeric; may have "-" and "_" as well.

https://umd-dit.atlassian.net/browse/LIBFCREPO-1363