### PR TITLE
LIBFCREPO-1488. Bumped django-umd-lib-style to 1.1.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ dependencies = [
     "django-htmx~=1.17",
     "django-safedelete~=1.3",
     "djangosaml2~=1.9",
-    "django-umd-lib-style@git+https://github.com/umd-lib/django-umd-lib-style.git@main",
+    "django-umd-lib-style>=1.1.0",
     # By default, Plastron Utils is installed from Github.
     # To use a local version for development, uncomment the following
     # line and comment the plastron-utils line with the Github URL


### PR DESCRIPTION
Enables the sandbox environment banner.

https://umd-dit.atlassian.net/browse/LIBFCREPO-1488