### PR TITLE
LIBFCREPO-1831. Update Django to 5.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -167,7 +167,8 @@ public/*
 **/grove*.crt
 **/grove*.key
 
-staticfiles
+staticfiles/*
+!staticfiles/.keep
 
 # Ruff cache
 .ruff_cache

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,23 +2,23 @@
 name = "grove"
 version = "1.0.1"
 dependencies = [
-    "click~=8.1",
-    "django~=5.0",
-    "django-environ~=0.11",
-    "django-extensions~=3.2",
-    "django-htmx~=1.17",
-    "django-safedelete~=1.3",
-    "djangosaml2~=1.9",
-    "django-umd-lib-style>=1.1.0",
+    "click~=8.4",
+    "django~=5.2",
+    "django-environ~=0.13",
+    "django-extensions~=4.1",
+    "django-htmx~=1.27",
+    "django-safedelete~=1.4",
+    "djangosaml2~=1.12",
+    "django-umd-lib-style>=1.2.0",
     # By default, Plastron Utils is installed from Github.
     # To use a local version for development, uncomment the following
     # line and comment the plastron-utils line with the Github URL
-    # "plastron-utils~=4.0",
-    "plastron-utils@git+https://github.com/umd-lib/plastron.git@4.0.0#subdirectory=plastron-utils",
-    "rdflib~=7.0",
+    # "plastron-utils~=4.8",
+    "plastron-utils@git+https://github.com/umd-lib/plastron.git@4.8.1#subdirectory=plastron-utils",
+    "rdflib~=7.6",
     'urlobject~=2.4',
     "waitress~=3.0",
-    "whitenoise~=6.6",
+    "whitenoise~=6.12",
 ]
 
 [project.optional-dependencies]
@@ -28,12 +28,12 @@ prod = [
 test = [
     "debugpy~=1.8",
     "freezegun~=1.5",
-    "pipdeptree~=2.16",
-    "pytest~=8.1",
-    "pytest-cov~=4.1",
-    "pytest-datadir~=1.5",
-    "pytest-django~=4.8",
-    "ruff~=0.3",
+    "pipdeptree~=2.35",
+    "pytest~=9.0",
+    "pytest-cov~=7.1",
+    "pytest-datadir~=1.8",
+    "pytest-django~=4.12",
+    "ruff~=0.15",
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "grove"
-version = "1.0.1"
+version = "1.1.0-dev"
 dependencies = [
     "click~=8.4",
     "django~=5.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ test = [
 [project.scripts]
 grove = "grove.server:run"
 
-[tool.pytest.ini_options]
+[tool.pytest]
 DJANGO_SETTINGS_MODULE = "grove.settings"
 
 [tool.coverage.run]


### PR DESCRIPTION
## Update dependencies for Django 5.2

The "pyproject.toml" is using "compatible version" specifier for
most dependencies. Because there is no "requirements.txt" or other
"lock" file, this means that most dependencies update to the
latest minor version automatically, whenever the dependencies are
installed.

For example, the `"django~=5.0"` dependency automatically uses
Django 5.2.14 in a fresh install on a local workstation, because that
is permitted by the "compatible version" specifier.

For this commit, updated the version specifier to be closer to the
actual version being used, reflecting those being automatically checked
out.

The exceptions are the following dependencies, which were updated to
versions not automatically reached by the existing "compatible version"
specifier:

* django-extensions - updated to `"django-extensions~=4.1"`
* plastron-utils - updated  to `"plastron-utils@git+https://github.com/umd-lib/plastron.git@4.8.1#subdirectory=plastron-utils"`
* pytest - updated to `"pytest~=9.0"`
* pytest-cov - updated to `"pytest-cov~=7.1"`

## Additional Changes

* pytest “pyproject.toml” configuration update - pytest v9.0.0 now supports “native TOML configuration files.”, meaning that the old “INI compatibility mode” specifier, so replaced `[tool.pytest.ini_options]` with the native TOML configuration `[tool.pytest]`

https://umd-dit.atlassian.net/browse/LIBFCREPO-1831